### PR TITLE
update(main.tf)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,10 @@ locals {
     "1.9.1-cpu" = "1.9.1-transformers${var.transformers_version}-cpu-py38-ubuntu20.04"
     "1.10.2-gpu" = "1.10.2-transformers${var.transformers_version}-gpu-py38-cu113-ubuntu20.04"
     "1.10.2-cpu" = "1.10.2-transformers${var.transformers_version}-cpu-py38-ubuntu20.04"
+    "1.13.1-cpu" = "1.13.1-transformers${var.transformers_version}-cpu-py39-ubuntu20.04"
+    "1.13.1-gpu" = "1.13.1-transformers${var.transformers_version}-gpu-py39-cu117-ubuntu20.04"
+    "2.0.0-cpu" = "2.0.0-transformers${var.transformers_version}-cpu-py310-ubuntu20.04"
+    "2.0.0-gpu" = "2.0.0-transformers${var.transformers_version}-gpu-py310-cu118-ubuntu20.04"
   }
   tensorflow_image_tag = {
     "2.4.1-gpu" = "2.4.1-transformers${var.transformers_version}-gpu-py37-cu110-ubuntu18.04"


### PR DESCRIPTION
At the moment we support transformers==1.10.2 in sagemaker endpoints, recent models require newer version of transformers. AWS has made available sagemaker images that support 1.13.1 and 2.0.0, this MR will allow us to use the newer images.

@ale-delfino